### PR TITLE
update TransferIntent id type to bytes32

### DIFF
--- a/contracts/interfaces/ITransfers.sol
+++ b/contracts/interfaces/ITransfers.sol
@@ -23,7 +23,7 @@ struct TransferIntent {
     address recipientCurrency;
     address refundDestination;
     uint256 feeAmount;
-    bytes16 id;
+    bytes32 id;
     address operator;
     bytes signature;
     bytes prefix;
@@ -52,7 +52,7 @@ interface ITransfers {
     // @param spentCurrency What currency the payer sent
     event Transferred(
         address indexed operator,
-        bytes16 id,
+        bytes32 id,
         address recipient,
         address sender,
         uint256 spentAmount,

--- a/contracts/transfers/Transfers.sol
+++ b/contracts/transfers/Transfers.sol
@@ -34,7 +34,7 @@ contract Transfers is Context, Ownable, Pausable, ReentrancyGuard, Sweepable, IT
     mapping(address => address) private feeDestinations;
 
     // @dev Map of operator addresses to a map of transfer intent ids that have been processed
-    mapping(address => mapping(bytes16 => bool)) private processedTransferIntents;
+    mapping(address => mapping(bytes32 => bool)) private processedTransferIntents;
 
     // @dev Represents native token of a chain (e.g. ETH or MATIC)
     address private immutable NATIVE_CURRENCY = address(0);


### PR DESCRIPTION
Hi,

I was wondering if the `id` field of the `TransferIntent` could be updated to a `bytes32` instead of `bytes16`.

This would make it so the Keccak256 hash function could be used to generate predictable ids and be more compatible with other protocols generating ids with Keccak256.

For my use case, I'm using EAS (Ethereum Attestation Service) as a backend to create an on-chain eCommerce solution, and it would be nice if I could use an attestation UID (a Keccak256 hash of the attestation) as the `id` for the `TransferIntent`. This would make the relationship between an attestation and a `TransferIntent` simpler and more efficient.

<br>

Thanks for your consideration and for this awesome protocol.